### PR TITLE
Fix image tag suffix

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -48,9 +48,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            type=raw,value=${{ matrix.python-version }},enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch && matrix.python-version == '3.8' }}
-            type=edge,branch=main,enable=false
+            type=raw,value=${{ matrix.python-version }},suffix=,enable={{is_default_branch}}
+            type=raw,value=latest,suffix=,enable=${{ github.ref_name == github.event.repository.default_branch && matrix.python-version == '3.8' }}
+            type=edge,branch=main
           images: |
             name=${{ secrets.DOCKER_USERNAME }}/python-base-eval-layer,enable=false
             name=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}


### PR DESCRIPTION
This PR (hopefully) fixes the image tag suffix for images built on the main branch. The following tags should be created:

* 3.8, edge-3.8, main-3.8, latest
* 3.9, edge-3.9, main-3.9
* 3.10, edge-3.10, main-3.10

However, the versioned tag is suffixed as well, so we have these tags:

* 3.8-3.8, edge-3.8, main-3.8, latest
* 3.9-3.9, edge-3.9, main-3.9
* 3.10-3.10, edge-3.10, main-3.10

By setting the `suffix=`, this hopefully fixes that