### PR TITLE
Breaking: Change lambda task root directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ ARG PYTHON_VERSION
 # Base image is Python 3.8 provided by AWS Lambda in Docker Hub
 FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
 
-WORKDIR /app
-
 # These are visible, the image is public so secrets would be accessible anyways
 # We'd like these to be available if any evaluation function needs it...
 # TODO: ~Find a better way to do this~
@@ -18,14 +16,14 @@ ENV INVOKER_KEY=${INVOKER_KEY}
 ENV INVOKER_REGION=${INVOKER_REGION}
 
 # Install backend dependencies
-COPY requirements.txt base_requirements.txt
-RUN pip3 install -r base_requirements.txt
+COPY requirements.txt ${LAMBDA_TASK_ROOT}/app/base_requirements.txt
+RUN pip3 install -r ${LAMBDA_TASK_ROOT}/app/base_requirements.txt
 
 # Copy the scripts
-COPY __init__.py ./app/
-COPY handler.py ./app/
-COPY tests/*.py ./app/tests/
-COPY tools/*.py ./app/tools/
+COPY __init__.py ${LAMBDA_TASK_ROOT}/app/
+COPY handler.py ${LAMBDA_TASK_ROOT}/app/
+COPY tests/*.py ${LAMBDA_TASK_ROOT}/app/tests/
+COPY tools/*.py ${LAMBDA_TASK_ROOT}/app/tools/
 
 # Request-response-schemas repo/branch to use for validation
 ENV SCHEMAS_URL=https://raw.githubusercontent.com/lambda-feedback/request-response-schemas/master

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ ENV INVOKER_KEY=${INVOKER_KEY}
 ENV INVOKER_REGION=${INVOKER_REGION}
 
 # Install backend dependencies
-COPY requirements.txt ${LAMBDA_TASK_ROOT}/app/base_requirements.txt
-RUN pip3 install -r ${LAMBDA_TASK_ROOT}/app/base_requirements.txt
+COPY requirements.txt ${LAMBDA_TASK_ROOT}/base_requirements.txt
+RUN pip3 install -r ${LAMBDA_TASK_ROOT}/base_requirements.txt
 
 # Copy the scripts
 COPY __init__.py ${LAMBDA_TASK_ROOT}/app/


### PR DESCRIPTION
This PR changes the task root of the lambda function to use `LAMBDA_TASK_ROOT`, documented in [the AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/python-image.html#python-image-instructions) instead of a custom one.

The previous custom task root `/app` caused issues with creating and running the base image for newer lambda runtime versions.

This introduces a breaking change, as evaluation functions using the base layer need to copy their code to `LAMBDA_TASK_ROOT`. However, this only takes effect when deliberately choosing the new image hosted on github packages.