### PR TITLE
Feature/py3.11_3.12

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION
 
-# Base image is Python 3.8 provided by AWS Lambda in Docker Hub
+# Base image is Python 3.8/3.9/3.10/3.11/3.12 provided by AWS Lambda in Docker Hub
 FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
 
 WORKDIR /app


### PR DESCRIPTION
Updating the boilerplate docker image with the newer python version 3.11 and 3.12 available from public.ecr.aws/lambda/python:${PYTHON_VERSION}.

New docker images will be found under 'packages' of this repo as they are published to GitHub Packages instead of dockerhub (old boilerplate image on dockerhub: rabidsheep55/python-base-eval-layer is on python3.8)